### PR TITLE
Backend/ Return item API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,13 +2,12 @@ from database.database import create_table
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import PlainTextResponse
-from router import item, user
+from router import route
 
 create_table()
 
 app = FastAPI()
-app.include_router(user.router)
-app.include_router(item.router)
+app.include_router(route.router)
 
 
 @app.exception_handler(RequestValidationError)

--- a/backend/model/rental.py
+++ b/backend/model/rental.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import Union
 
 from model import Base
@@ -19,9 +20,9 @@ class Rental(Base, Timestamp):
         ForeignKey("items.id", onupdate="CASCADE", ondelete="RESTRICT"),
         nullable=False,
     )
-    rented_date: Union[Date, Column] = Column(Date, nullable=False)
-    return_plan_date: Union[Date, Column] = Column(Date, nullable=False)
-    returned_date: Union[Date, Column] = Column(Date, nullable=True)
+    rented_date: Union[date, Column] = Column(Date, nullable=False)
+    return_plan_date: Union[date, Column] = Column(Date, nullable=False)
+    returned_date: Union[date, Column] = Column(Date, nullable=True)
 
     users = relationship("User", back_populates="rentals")
     items = relationship("Item", back_populates="rentals")

--- a/backend/router/item.py
+++ b/backend/router/item.py
@@ -7,9 +7,7 @@ from store import ItemStore, ItemStoreInterface, RentalStore, RentalStoreInterfa
 from usecase import ItemUseCase, ItemUseCaseInterface
 from util.logging import get_logger
 
-router = APIRouter(
-    prefix="/items",
-)
+router = APIRouter()
 
 logger = get_logger()
 

--- a/backend/router/owned_item.py
+++ b/backend/router/owned_item.py
@@ -8,9 +8,7 @@ from usecase import ItemUseCase, ItemUseCaseInterface
 from util.error_msg import NotFoundError
 from util.logging import get_logger
 
-router = APIRouter(
-    prefix="/items",
-)
+router = APIRouter()
 
 logger = get_logger()
 

--- a/backend/router/rental.py
+++ b/backend/router/rental.py
@@ -13,9 +13,7 @@ from util.error_msg import (
 )
 from util.logging import get_logger
 
-router = APIRouter(
-    prefix="/rentals",
-)
+router = APIRouter()
 
 logger = get_logger()
 
@@ -33,9 +31,9 @@ def list_rental():
         {
             "id": 1,
             "closed": False,
-            "rental_date": "2022-06-06",
-            "return_plan_date": "2022-06-06",
-            "return_date": "2022-06-06",
+            "rentalDate": "2022-06-06",
+            "returnPlanDate": "2022-06-06",
+            "returnDate": "2022-06-06",
             "itemId": 1,
             "itemName": "item name",
         }
@@ -47,8 +45,8 @@ def get_rental(item_id: int):
     return [
         {
             "itemId": item_id,
-            "rental_date": "2022-06-06",
-            "return_plan_date": "2022-06-06",
+            "rentalDate": "2022-06-06",
+            "returnPlanDate": "2022-06-06",
         }
     ]
 

--- a/backend/router/rental.py
+++ b/backend/router/rental.py
@@ -1,7 +1,7 @@
 from database.database import get_db
 from database.transaction import Transaction, TransactionInterface
 from fastapi import APIRouter, Depends, HTTPException, status
-from schema import RentRequest, RentResponse
+from schema import RentRequest, RentResponse, ReturnParams
 from sqlalchemy.orm import Session
 from store import ItemStore, ItemStoreInterface, RentalStore, RentalStoreInterface
 from usecase import RentalUseCase, RentalUseCaseInterface
@@ -61,7 +61,7 @@ def rent_item(
     try:
         # TODO: headerのトークンからユーザーID取得
         user_id = 2
-        rental = rental_usecase.create_rental(req, user_id)
+        rental = rental_usecase.rent_item(req, user_id)
     except NotFoundError as err:
         logger.error(f"({__name__}): {err}")
         raise HTTPException(
@@ -90,6 +90,17 @@ def rent_item(
     return rental
 
 
-@router.put("/{rental_id}/return", status_code=status.HTTP_204_NO_CONTENT)
-def return_rental():
-    pass
+@router.put("/{rentalId}/return", status_code=status.HTTP_204_NO_CONTENT)
+def return_rental(
+    params: ReturnParams = Depends(),
+    rental_usecase: RentalUseCaseInterface = Depends(new_rental_usecase),
+):
+    try:
+        # TODO: headerのトークンからユーザーID取得
+        user_id = 1
+        rental_usecase.return_item(params, user_id)
+    except Exception as err:
+        logger.error(f"({__name__}): {err}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )

--- a/backend/router/rental.py
+++ b/backend/router/rental.py
@@ -97,8 +97,25 @@ def return_rental(
 ):
     try:
         # TODO: headerのトークンからユーザーID取得
-        user_id = 1
+        user_id = 3
         rental_usecase.return_item(params, user_id)
+    except NotFoundError as err:
+        logger.error(f"({__name__}): {err}")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Rental ID is not found"
+        )
+    except OperationIsForbiddenError as err:
+        logger.error(f"({__name__}): {err}")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This rental ID is not your rental",
+        )
+    except ResourceAlreadyExistsError as err:
+        logger.error(f"({__name__}): {err}")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This Rental is already returned",
+        )
     except Exception as err:
         logger.error(f"({__name__}): {err}")
         raise HTTPException(

--- a/backend/router/route.py
+++ b/backend/router/route.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+from router import item, owned_item, rental, user
+
+router = APIRouter()
+
+router.include_router(user.router, prefix="/users", tags=["users"])
+router.include_router(item.router, prefix="/items", tags=["items"])
+router.include_router(owned_item.router, prefix="/users/items", tags=["owned_items"])
+router.include_router(rental.router, prefix="/users/rentals", tags=["rentals"])

--- a/backend/router/user.py
+++ b/backend/router/user.py
@@ -1,12 +1,6 @@
 from fastapi import APIRouter, status
-from router import owned_item, rental
 
-router = APIRouter(
-    prefix="/users",
-)
-
-router.include_router(owned_item.router)
-router.include_router(rental.router)
+router = APIRouter()
 
 
 @router.get("/profile")

--- a/backend/schema/__init__.py
+++ b/backend/schema/__init__.py
@@ -5,7 +5,7 @@ from schema.item import (
     ItemResponse,
     ItemStatus,
 )
-from schema.rental import RentRequest, RentResponse
+from schema.rental import RentRequest, RentResponse, ReturnParams
 
 __all__ = [
     "ItemStatus",
@@ -15,4 +15,5 @@ __all__ = [
     "ItemCreateResponse",
     "RentRequest",
     "RentResponse",
+    "ReturnParams",
 ]

--- a/backend/schema/rental.py
+++ b/backend/schema/rental.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from fastapi import Path
 from pydantic import BaseModel, Field
 
 
@@ -15,3 +16,7 @@ class RentResponse(BaseModel):
     @classmethod
     def new(cls, id):
         return cls(id=id)
+
+
+class ReturnParams(BaseModel):
+    rental_id: int = Field(Path(alias="rentalId"))

--- a/backend/usecase/rental.py
+++ b/backend/usecase/rental.py
@@ -3,7 +3,7 @@ import abc
 import model
 from database.transaction import TransactionInterface
 from psycopg2.errors import ForeignKeyViolation, UniqueViolation
-from schema import RentRequest, RentResponse
+from schema import RentRequest, RentResponse, ReturnParams
 from store import ItemStoreInterface, RentalStoreInterface
 from util.error_msg import (
     NotFoundError,
@@ -18,7 +18,10 @@ logger = get_logger()
 
 class RentalUseCaseInterface(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def create_rental(self, req: RentRequest, user_id: int) -> RentResponse:
+    def rent_item(self, req: RentRequest, user_id: int) -> RentResponse:
+        raise NotImplementedError
+
+    def return_item(self, params: ReturnParams, user_id: int) -> None:
         raise NotImplementedError
 
 
@@ -33,7 +36,7 @@ class RentalUseCase(RentalUseCaseInterface):
         self.item_store: ItemStoreInterface = item
         self.rental_store: RentalStoreInterface = rental
 
-    def create_rental(self, req: RentRequest, user_id: int) -> RentResponse:
+    def rent_item(self, req: RentRequest, user_id: int) -> RentResponse:
         try:
             item: model.Item = self.item_store.detail(req.item_id)
             if item is None:
@@ -64,3 +67,6 @@ class RentalUseCase(RentalUseCaseInterface):
             logger.error(f"({__name__}): {err}")
             self.tx.rollback()
             raise
+
+    def return_item(self, params: ReturnParams, user_id: int) -> None:
+        raise NotImplementedError

--- a/backend/usecase/rental.py
+++ b/backend/usecase/rental.py
@@ -35,7 +35,7 @@ class RentalUseCase(RentalUseCaseInterface):
 
     def create_rental(self, req: RentRequest, user_id: int) -> RentResponse:
         try:
-            item: model.Item = self.item_store.detail(req.itemId)
+            item: model.Item = self.item_store.detail(req.item_id)
             if item is None:
                 raise NotFoundError
             if item.owner_id == user_id:
@@ -45,9 +45,9 @@ class RentalUseCase(RentalUseCaseInterface):
 
             rental = model.Rental(
                 user_id=user_id,
-                item_id=req.itemId,
-                rented_date=req.rentalDate,
-                return_plan_date=req.returnPlanDate,
+                item_id=req.item_id,
+                rented_date=req.rental_date,
+                return_plan_date=req.return_plan_date,
             )
             self.rental_store.create(rental)
             self.tx.commit()

--- a/backend/usecase/rental.py
+++ b/backend/usecase/rental.py
@@ -1,4 +1,6 @@
 import abc
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import model
 from database.transaction import TransactionInterface
@@ -69,4 +71,34 @@ class RentalUseCase(RentalUseCaseInterface):
             raise
 
     def return_item(self, params: ReturnParams, user_id: int) -> None:
-        raise NotImplementedError
+        try:
+            existing_rental = self.rental_store.detail(params.rental_id)
+            if existing_rental is None:
+                raise NotFoundError
+            if existing_rental.user_id != user_id:
+                raise OperationIsForbiddenError
+            if existing_rental.returned_date is not None:
+                raise ResourceAlreadyExistsError
+
+            rental = model.Rental(
+                id=existing_rental.id,
+                user_id=existing_rental.user_id,
+                item_id=existing_rental.item_id,
+                rented_date=existing_rental.rented_date,
+                return_plan_date=existing_rental.return_plan_date,
+                returned_date=datetime.now(ZoneInfo("Asia/Tokyo")).date(),
+            )
+            self.rental_store.update(rental)
+            self.tx.commit()
+        except UniqueViolation as err:
+            logger.error(f"({__name__}): {err}")
+            self.tx.rollback()
+            raise ResourceAlreadyExistsError
+        except ForeignKeyViolation as err:
+            logger.error(f"({__name__}): {err}")
+            self.tx.rollback()
+            raise NotFoundError
+        except Exception as err:
+            logger.error(f"({__name__}): {err}")
+            self.tx.rollback()
+            raise

--- a/docs/api/path/users.rentals.yaml
+++ b/docs/api/path/users.rentals.yaml
@@ -185,3 +185,5 @@ paths:
           description: Rental ID is not your rental
         "404":
           description: Rental ID is not found
+        "409":
+          description: This Rental is already returned


### PR DESCRIPTION
## 説明
<!-- 変更内容を記載してください -->
item返却API `PUT /users/rentals/{rentalId}/return` を実装しました。
レンタルしていたitemを返却できるようになりました。

返却できるitem:
* 自分のuserIDでレンタルしたitemであること
* すでに返却されたitemでないこと
* 存在するItemIDであること

### コミット
<!-- 主要な commit とその変更内容を記載 -->
- routerの実装: 6c441b3c396de0b1c5252bdb5b1c367737bd3c1a
- storeの実装: cd797c38bc2e9e0d192e70823ecbd25d5527fc40
- usecaseの実装: 54188c03b8c30162a53ba69e729cb5ebcfa2010b
- routeの設定: 057f95b97d2b00e213445f8463056192721f053e

## 動作確認
<!-- 動作確認の内容を記載してください -->
<!-- 確認手順・結果など -->
* APIサーバー起動＆サンプルデータの挿入（PCのターミナルで実行）
  ```sh
  cd backend
  make run-prod
  ```
  別ターミナルで実行
  ```
  docker exec -it chankari-backend python sample_data_creation.py 
  ```
* 返却APIの呼び出し
  * 正常系
    ```sh
    curl --location --request PUT 'localhost:8000/users/rentals/2/return'
    ```
    レスポンスなし (204)

  * すでに返却済みの場合
    ```sh
    curl --location --request PUT 'localhost:8000/users/rentals/2/return'
    ```
      レスポンス (409)
    ```sh
    {
        "detail": "This Rental is already returned"
    }
    ```

  * 自分の予約ではない場合
    ```sh
    curl --location --request PUT 'localhost:8000/users/rentals/1/return'
    ```
    レスポンス (403)
    ```
    {
        "detail": "This rental ID is not your rental"
    }
    ```

## 問題点
<!-- 問題点があれば記載 -->
認証実装まではユーザー情報は固定値です(user_id=3)
