### PR TITLE
Backend/ Rental list API

### DIFF
--- a/backend/router/rental.py
+++ b/backend/router/rental.py
@@ -1,7 +1,13 @@
 from database.database import get_db
 from database.transaction import Transaction, TransactionInterface
 from fastapi import APIRouter, Depends, HTTPException, status
-from schema import RentRequest, RentResponse, ReturnParams
+from schema import (
+    RentalListParams,
+    RentalResponse,
+    RentRequest,
+    RentResponse,
+    ReturnParams,
+)
 from sqlalchemy.orm import Session
 from store import ItemStore, ItemStoreInterface, RentalStore, RentalStoreInterface
 from usecase import RentalUseCase, RentalUseCaseInterface
@@ -25,19 +31,20 @@ def new_rental_usecase(db: Session = Depends(get_db)) -> RentalUseCaseInterface:
     return RentalUseCase(tx, item_store, renal_store)
 
 
-@router.get("")
-def list_rental():
-    return [
-        {
-            "id": 1,
-            "closed": False,
-            "rentalDate": "2022-06-06",
-            "returnPlanDate": "2022-06-06",
-            "returnDate": "2022-06-06",
-            "itemId": 1,
-            "itemName": "item name",
-        }
-    ]
+@router.get("", response_model=list[RentalResponse])
+def list_rental(
+    params: RentalListParams = Depends(),
+    rental_usecase: RentalUseCaseInterface = Depends(new_rental_usecase),
+):
+    try:
+        # TODO: headerのトークンからユーザーID取得
+        user_id = 2
+        return rental_usecase.get_my_list(params, user_id)
+    except Exception as err:
+        logger.error(f"({__name__}): {err}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
 
 
 @router.get("/{item_id}")
@@ -59,7 +66,7 @@ def rent_item(
     try:
         # TODO: headerのトークンからユーザーID取得
         user_id = 2
-        rental = rental_usecase.rent_item(req, user_id)
+        return rental_usecase.rent_item(req, user_id)
     except NotFoundError as err:
         logger.error(f"({__name__}): {err}")
         raise HTTPException(
@@ -85,7 +92,6 @@ def rent_item(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
-    return rental
 
 
 @router.put("/{rentalId}/return", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/schema/__init__.py
+++ b/backend/schema/__init__.py
@@ -5,7 +5,13 @@ from schema.item import (
     ItemResponse,
     ItemStatus,
 )
-from schema.rental import RentRequest, RentResponse, ReturnParams
+from schema.rental import (
+    RentalListParams,
+    RentalResponse,
+    RentRequest,
+    RentResponse,
+    ReturnParams,
+)
 
 __all__ = [
     "ItemStatus",
@@ -16,4 +22,6 @@ __all__ = [
     "RentRequest",
     "RentResponse",
     "ReturnParams",
+    "RentalListParams",
+    "RentalResponse",
 ]

--- a/backend/schema/__init__.py
+++ b/backend/schema/__init__.py
@@ -5,6 +5,7 @@ from schema.item import (
     ItemResponse,
     ItemStatus,
 )
+from schema.pagination import PaginationQuery
 from schema.rental import (
     RentalListParams,
     RentalResponse,
@@ -14,6 +15,7 @@ from schema.rental import (
 )
 
 __all__ = [
+    "PaginationQuery",
     "ItemStatus",
     "ItemListParams",
     "ItemResponse",

--- a/backend/schema/item.py
+++ b/backend/schema/item.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 from fastapi import Query
 from pydantic import BaseModel, Field
-from schema.pagination import PaginationQuery
 
 
 class ItemStatus(str, Enum):
@@ -12,7 +11,7 @@ class ItemStatus(str, Enum):
     rented = "rented"
 
 
-class ItemListParams(PaginationQuery):
+class ItemListParams(BaseModel):
     available: Optional[str] = Field(Query(default=None))
 
 

--- a/backend/schema/rental.py
+++ b/backend/schema/rental.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 from fastapi import Path, Query
 from pydantic import BaseModel, Field
-from schema.pagination import PaginationQuery
 
 
 class RentRequest(BaseModel):
@@ -24,7 +23,7 @@ class ReturnParams(BaseModel):
     rental_id: int = Field(Path(alias="rentalId"))
 
 
-class RentalListParams(PaginationQuery):
+class RentalListParams(BaseModel):
     closed: Optional[str] = Field(Query(default=None))
 
 

--- a/backend/schema/rental.py
+++ b/backend/schema/rental.py
@@ -1,7 +1,9 @@
 from datetime import date
+from typing import Optional
 
-from fastapi import Path
+from fastapi import Path, Query
 from pydantic import BaseModel, Field
+from schema.pagination import PaginationQuery
 
 
 class RentRequest(BaseModel):
@@ -20,3 +22,31 @@ class RentResponse(BaseModel):
 
 class ReturnParams(BaseModel):
     rental_id: int = Field(Path(alias="rentalId"))
+
+
+class RentalListParams(PaginationQuery):
+    closed: Optional[str] = Field(Query(default=None))
+
+
+class RentalResponse(BaseModel):
+    id: int
+    closed: bool
+    rental_date: date = Field(alias="rentalDate")
+    return_plan_date: date = Field(alias="returnPlanDate")
+    return_date: Optional[date] = Field(alias="returnDate")
+    item_id: int = Field(alias="itemId")
+    item_name: str = Field(alias="itemName")
+
+    @classmethod
+    def new(
+        cls, id, closed, rental_date, return_plan_date, return_date, item_id, item_name
+    ):
+        return cls(
+            id=id,
+            closed=closed,
+            rentalDate=rental_date,
+            returnPlanDate=return_plan_date,
+            returnDate=return_date,
+            itemId=item_id,
+            itemName=item_name,
+        )

--- a/backend/store/util.py
+++ b/backend/store/util.py
@@ -1,0 +1,30 @@
+from typing import Any, TypeVar
+
+from schema import PaginationQuery
+from sqlalchemy import desc
+from sqlalchemy.orm import Query
+
+T = TypeVar("T")
+
+
+def pagination_query(
+    model: T,
+    q: Query,
+    pagination: PaginationQuery,
+    id: Any,
+) -> list[T]:
+    if pagination.after is not None:
+        return (
+            q.order_by(desc(id))
+            .filter(id < pagination.after)
+            .limit(pagination.limit)
+            .all()
+        )
+    elif pagination.before is not None:
+        resources = (
+            q.order_by(id).offset(pagination.before).limit(pagination.limit).all()
+        )
+        resources.reverse()
+        return resources
+    else:
+        return q.order_by(desc(id)).limit(pagination.limit).all()

--- a/backend/usecase/item.py
+++ b/backend/usecase/item.py
@@ -48,7 +48,7 @@ class ItemUseCase(ItemUseCaseInterface):
             item_res_list: list[ItemResponse] = []
             for item in items:
                 if not item.available:
-                    status: ItemStatus = ItemStatus.unavailable
+                    continue
                 elif (
                     len(list(filter(lambda r: r.item_id == item.id, valid_rentals)))
                     != 0
@@ -59,16 +59,14 @@ class ItemUseCase(ItemUseCaseInterface):
                 item_res_list.append(
                     ItemResponse.new(item.id, item.name, status, item.image_url)
                 )
+            if bool(params.available):
+                return list(
+                    filter(lambda i: i.status == ItemStatus.available, item_res_list)
+                )
+            return item_res_list
         except Exception as err:
             logger.error(f"({__name__}): {err}")
             raise
-
-        if bool(params.available):
-            return list(
-                filter(lambda i: i.status == ItemStatus.available, item_res_list)
-            )
-
-        return item_res_list
 
     def create_item(self, req: ItemCreateRequest, user_id: int) -> ItemCreateResponse:
         try:

--- a/backend/usecase/item.py
+++ b/backend/usecase/item.py
@@ -9,6 +9,7 @@ from schema import (
     ItemListParams,
     ItemResponse,
     ItemStatus,
+    PaginationQuery,
 )
 from store import ItemStoreInterface, RentalStoreInterface
 from util.error_msg import NotFoundError
@@ -19,7 +20,9 @@ logger = get_logger()
 
 class ItemUseCaseInterface(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def get_list(self, params: ItemListParams) -> list[ItemResponse]:
+    def get_list(
+        self, pagination: PaginationQuery, params: ItemListParams
+    ) -> list[ItemResponse]:
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -38,11 +41,11 @@ class ItemUseCase(ItemUseCaseInterface):
         self.item_store: ItemStoreInterface = item
         self.rental_store: RentalStoreInterface = rental
 
-    def get_list(self, params: ItemListParams) -> list[ItemResponse]:
+    def get_list(
+        self, pagination: PaginationQuery, params: ItemListParams
+    ) -> list[ItemResponse]:
         try:
-            items: list[model.Item] = self.item_store.list_available(
-                params.limit, params.after, params.before
-            )
+            items: list[model.Item] = self.item_store.list_available(pagination)
             valid_rentals: list[model.Rental] = self.rental_store.list_valid()
 
             item_res_list: list[ItemResponse] = []

--- a/backend/usecase/rental.py
+++ b/backend/usecase/rental.py
@@ -5,7 +5,13 @@ from zoneinfo import ZoneInfo
 import model
 from database.transaction import TransactionInterface
 from psycopg2.errors import ForeignKeyViolation, UniqueViolation
-from schema import RentRequest, RentResponse, ReturnParams
+from schema import (
+    RentalListParams,
+    RentalResponse,
+    RentRequest,
+    RentResponse,
+    ReturnParams,
+)
 from store import ItemStoreInterface, RentalStoreInterface
 from util.error_msg import (
     NotFoundError,
@@ -23,7 +29,14 @@ class RentalUseCaseInterface(metaclass=abc.ABCMeta):
     def rent_item(self, req: RentRequest, user_id: int) -> RentResponse:
         raise NotImplementedError
 
+    @abc.abstractmethod
     def return_item(self, params: ReturnParams, user_id: int) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_my_list(
+        self, params: RentalListParams, user_id: int
+    ) -> list[RentalResponse]:
         raise NotImplementedError
 
 
@@ -102,3 +115,8 @@ class RentalUseCase(RentalUseCaseInterface):
             logger.error(f"({__name__}): {err}")
             self.tx.rollback()
             raise
+
+    def get_my_list(
+        self, params: RentalListParams, user_id: int
+    ) -> list[RentalResponse]:
+        raise NotImplementedError


### PR DESCRIPTION
## 説明
<!-- 変更内容を記載してください -->
自分がレンタルしているもの一覧取得API `GET /users/rentals `を実装しました。
* `closed`クエリ無しでリクエストすると今現在レンタル中(=返却していない)のものだけ取得できます。
* `closed`クエリを付けてリクエストすると過去のレンタル履歴も含んだ結果が取得できます。
* 最新のレンタルが一番上に来るようになっています。

その他
* `GET /users/items`の並び順も最新が一番上に来るように並び変えました。
* `GET /users/items`の結果にunavailableのものも含まれていたので含まないように修正しました。

### コミット
<!-- 主要な commit とその変更内容を記載 -->
- 40514924251891dff4ae7fbaafd6737531e341b8: `GET /users/items`の結果にunavailableが含まないように変更
- 803ad70ff731032d5951ad781ee17c5e078961f0: routerの実装
- 4f4c4a1ef777fffaf6f845aafa7dfdde67e308a5, 4f4c4a1ef777fffaf6f845aafa7dfdde67e308a5: ページネーション処理の共通化とstoreの実装
- cf1209a6718ebde10c1b819783c43284ca270b5a: usecaseの実装

## 動作確認
<!-- 動作確認の内容を記載してください -->
<!-- 確認手順・結果など -->
* APIサーバー起動＆サンプルデータの挿入（PCのターミナルで実行）
  ```sh
  cd backend
  make run-prod
  ```
  別ターミナルで実行
  ```
  docker exec -it chankari-backend python sample_data_creation.py 
  ```
* 返却APIの呼び出し
  * 正常系 (`closed`クエリ無し)
    ```sh
    curl --location --request GET 'localhost:8000/users/rentals'
    ```
    レスポン (200) レンタル中のものが存在しない
    ```
    []
    ```

  * 正常系 (`closed`クエリあり)
    ```sh
    curl --location --request GET 'localhost:8000/users/rentals?closed=true'
    ```
      レスポンス (200) 過去の予約履歴
    ```sh
    [
      {
          "id": 1,
          "closed": true,
          "rentalDate": "2023-01-01",
          "returnPlanDate": "2023-01-10",
          "returnDate": "2023-01-08",
          "itemId": 1,
          "itemName": "sample_item_1"
      }
    ]
    ```

## 問題点
<!-- 問題点があれば記載 -->
user_idは固定値です

