### PR TITLE
Backend/ Owned item list API

### DIFF
--- a/backend/router/rental.py
+++ b/backend/router/rental.py
@@ -37,7 +37,7 @@ def list_rental(
     params: RentalListParams = Depends(),
     pagination: PaginationQuery = Depends(),
     rental_usecase: RentalUseCaseInterface = Depends(new_rental_usecase),
-):
+) -> list[RentalResponse]:
     if pagination.after is not None and pagination.before is not None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -105,7 +105,7 @@ def rent_item(
 def return_rental(
     params: ReturnParams = Depends(),
     rental_usecase: RentalUseCaseInterface = Depends(new_rental_usecase),
-):
+) -> None:
     try:
         # TODO: headerのトークンからユーザーID取得
         user_id = 3

--- a/backend/store/item.py
+++ b/backend/store/item.py
@@ -55,6 +55,16 @@ class ItemStore(ItemStoreInterface):
             logger.error(f"({__name__}): {err}")
             raise
 
+    def list_by_user_id(
+        self, pagination: PaginationQuery, user_id: int
+    ) -> list[model.Item]:
+        try:
+            q = self.db.query(model.Item).filter(model.Item.owner_id == user_id)
+            return pagination_query(model.Item, q, pagination, model.Item.id)
+        except Exception as err:
+            logger.error(f"({__name__}): {err}")
+            raise
+
     def list(self) -> list[model.Item]:
         raise NotImplementedError()
 

--- a/backend/store/item.py
+++ b/backend/store/item.py
@@ -17,6 +17,12 @@ class ItemStoreInterface(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def list_by_user_id(
+        self, pagination: PaginationQuery, user_id: int
+    ) -> list[model.Item]:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def list(self) -> list[model.Item]:
         raise NotImplementedError()
 

--- a/backend/usecase/item.py
+++ b/backend/usecase/item.py
@@ -26,6 +26,12 @@ class ItemUseCaseInterface(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def get_my_list(
+        self, pagination: PaginationQuery, user_id: int
+    ) -> list[ItemResponse]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def create_item(self, req: ItemCreateRequest, user_id: int) -> ItemCreateResponse:
         raise NotImplementedError
 
@@ -70,6 +76,11 @@ class ItemUseCase(ItemUseCaseInterface):
         except Exception as err:
             logger.error(f"({__name__}): {err}")
             raise
+
+    def get_my_list(
+        self, pagination: PaginationQuery, user_id: int
+    ) -> list[ItemResponse]:
+        raise NotImplementedError
 
     def create_item(self, req: ItemCreateRequest, user_id: int) -> ItemCreateResponse:
         try:

--- a/backend/usecase/item.py
+++ b/backend/usecase/item.py
@@ -80,7 +80,30 @@ class ItemUseCase(ItemUseCaseInterface):
     def get_my_list(
         self, pagination: PaginationQuery, user_id: int
     ) -> list[ItemResponse]:
-        raise NotImplementedError
+        try:
+            items: list[model.Item] = self.item_store.list_by_user_id(
+                pagination, user_id
+            )
+            valid_rentals: list[model.Rental] = self.rental_store.list_valid()
+
+            item_res_list: list[ItemResponse] = []
+            for item in items:
+                if not item.available:
+                    status: ItemStatus = ItemStatus.unavailable
+                elif (
+                    len(list(filter(lambda r: r.item_id == item.id, valid_rentals)))
+                    != 0
+                ):
+                    status: ItemStatus = ItemStatus.rented
+                else:
+                    status: ItemStatus = ItemStatus.available
+                item_res_list.append(
+                    ItemResponse.new(item.id, item.name, status, item.image_url)
+                )
+            return item_res_list
+        except Exception as err:
+            logger.error(f"({__name__}): {err}")
+            raise
 
     def create_item(self, req: ItemCreateRequest, user_id: int) -> ItemCreateResponse:
         try:


### PR DESCRIPTION
## 説明
<!-- 変更内容を記載してください -->
所有品リスト取得API`GET /users/items`を実装しました。
ステータス(レンタル中かどうか、非公開かどうか)付きで所有するitemを返しています。

* ページネーション用のクエリをつけています

### コミット
<!-- 主要な commit とその変更内容を記載 -->
* routerの実装: 49ac7ca94611e730c5d8704fbccd67c35fa36f9e
* usecaseの実装: d155d95fffb24b65b09c829691cdd4409e2132a2
* storeの実装: b70aead038b987d898e05b5c7b7c14d56c0b9908

## 動作確認
<!-- 動作確認の内容を記載してください -->
<!-- 確認手順・結果など -->
* APIサーバー起動＆サンプルデータの挿入（PCのターミナルで実行）
  ```sh
  cd backend
  make run-prod
  ```
  別ターミナルで実行
  ```
  docker exec -it chankari-backend python sample_data_creation.py 
  ```
* APIの呼び出し
  * 正常系 (`closed`クエリ無し)
    ```sh
    curl --location --request GET 'localhost:8000/users/items'
    ```
    所有するitemが取得できること


## 問題点
<!-- 問題点があれば記載 -->
特になし
